### PR TITLE
Expand environment placeholders for user-specific paths

### DIFF
--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -14,3 +14,12 @@ def test_paths_whitelist():
     whitelist = paths_cfg.get("whitelist")
     assert isinstance(whitelist, list)
     assert any("Documents" in path for path in whitelist)
+
+
+def test_paths_username_expansion(monkeypatch):
+    refresh_cache()
+    monkeypatch.setenv("USERNAME", "TestUser")
+    paths_cfg = load_config("paths")
+    whitelist = paths_cfg.get("whitelist", [])
+    assert any("TestUser" in path for path in whitelist)
+    assert paths_cfg.get("default_downloads") == r"C:\Users\TestUser\Downloads"


### PR DESCRIPTION
## Summary
- expand environment variables and user home references in configuration values when loading configs
- add support for Windows-style %VAR% placeholders so per-user paths resolve automatically
- cover the new behaviour with a test that validates username expansion in the paths config

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8fad1560c83208683f1ae89954786