### PR TITLE
Integrate local LLM responses and browser selection flow

### DIFF
--- a/config/apps.yml
+++ b/config/apps.yml
@@ -20,3 +20,11 @@ apps:
     title: "Google Chrome"
     command: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
     process_name: "chrome.exe"
+  edge:
+    title: "Microsoft Edge"
+    command: "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe"
+    process_name: "msedge.exe"
+  firefox:
+    title: "Mozilla Firefox"
+    command: "C:\\Program Files\\Mozilla Firefox\\firefox.exe"
+    process_name: "firefox.exe"

--- a/tests/test_dialog_context.py
+++ b/tests/test_dialog_context.py
@@ -57,6 +57,7 @@ def test_dialog_context(dialog_router: IntentRouter, monkeypatch: pytest.MonkeyP
     ]
     expected_paths = [str(Path(path).expanduser().resolve(strict=False)) for path in fake_results]
 
+    monkeypatch.setattr("tools.search.search_files", lambda *args, **kwargs: expected_paths)
     monkeypatch.setattr("tools.search.search_local", lambda *args, **kwargs: expected_paths)
 
     opened: List[str] = []

--- a/tests/test_llm_and_browser.py
+++ b/tests/test_llm_and_browser.py
@@ -1,0 +1,50 @@
+import pytest
+
+from intent_router import AgentSession, IntentRouter, SessionState
+
+
+@pytest.fixture()
+def router(monkeypatch):
+    router = IntentRouter()
+    # Отключаем реальные обращения к Everything и приложениям в тестах
+    monkeypatch.setattr(router.llm, "generate", lambda prompt, model=None, stream=True: "Тестовый ответ")
+    return router
+
+
+def test_smalltalk_uses_llm(router):
+    session = AgentSession()
+    state = {"session_state": SessionState()}
+    response = router.handle_message("кто ты?", session, state)
+    assert response["reply"].startswith("Тестовый ответ")
+
+
+def test_open_browser_requires_choice(monkeypatch):
+    router = IntentRouter()
+    session = AgentSession()
+    state = {"session_state": SessionState()}
+
+    monkeypatch.setattr(router.llm, "generate", lambda prompt, model=None, stream=True: "Тестовый ответ")
+
+    available = {"chrome", "edge"}
+    launches: list[str] = []
+
+    monkeypatch.setattr(
+        "intent_router.apps_module.is_installed",
+        lambda app_id: app_id in available,
+    )
+    monkeypatch.setattr(
+        "intent_router.apps_module.launch",
+        lambda app_id: launches.append(app_id) or {"ok": True, "message": "ok", "path": app_id},
+    )
+
+    response = router.handle_message("открой браузер", session, state)
+    assert "Какой браузер открыть?" in response["reply"]
+    assert not launches
+    assert session.awaiting_browser_choice is True
+    assert set(session.available_browsers) == available
+
+    response_choice = router.handle_message("хром", session, state)
+    assert launches == ["chrome"]
+    assert session.preferred_browser == "chrome"
+    assert session.awaiting_browser_choice is False
+    assert response_choice["ok"] is True

--- a/tools/llm_client.py
+++ b/tools/llm_client.py
@@ -1,0 +1,77 @@
+"""Клиент для взаимодействия с локальной Ollama."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional
+from urllib import error, request
+
+
+class OllamaClient:
+    """Простой HTTP-клиент для Ollama REST API."""
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:11434",
+        default_model: str = "llama3.1:8b",
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.default_model = default_model
+
+    def _post(self, endpoint: str, payload: Dict[str, object], stream: bool) -> str:
+        url = f"{self.base_url}{endpoint}"
+        data = json.dumps(payload).encode("utf-8")
+        req = request.Request(url, data=data, method="POST")
+        req.add_header("Content-Type", "application/json")
+        try:
+            with request.urlopen(req) as response:  # noqa: S310 - локальное подключение
+                if stream:
+                    chunks: List[str] = []
+                    for raw_line in response:
+                        line = raw_line.decode("utf-8").strip()
+                        if not line:
+                            continue
+                        try:
+                            message = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        chunk = self._extract_text(message)
+                        if chunk:
+                            chunks.append(chunk)
+                    return "".join(chunks)
+                payload_raw = response.read().decode("utf-8")
+                message = json.loads(payload_raw) if payload_raw else {}
+                return self._extract_text(message)
+        except (error.URLError, error.HTTPError, OSError, json.JSONDecodeError) as exc:
+            return f"Модель недоступна. Ошибка: {exc}"
+        except Exception as exc:  # pragma: no cover - защита от неожиданных ошибок
+            return f"Модель недоступна. Ошибка: {exc}"
+
+    @staticmethod
+    def _extract_text(message: Dict[str, object]) -> str:
+        if not isinstance(message, dict):
+            return ""
+        if "response" in message and isinstance(message["response"], str):
+            return message["response"]
+        chat_message = message.get("message")
+        if isinstance(chat_message, dict):
+            content = chat_message.get("content")
+            if isinstance(content, str):
+                return content
+        return ""
+
+    def generate(self, prompt: str, model: Optional[str] = None, stream: bool = True) -> str:
+        payload: Dict[str, object] = {
+            "model": model or self.default_model,
+            "prompt": prompt,
+            "stream": stream,
+        }
+        return self._post("/api/generate", payload, stream=stream)
+
+    def chat(self, messages: List[Dict[str, object]], model: Optional[str] = None, stream: bool = True) -> str:
+        payload: Dict[str, object] = {
+            "model": model or self.default_model,
+            "messages": messages,
+            "stream": stream,
+        }
+        return self._post("/api/chat", payload, stream=stream)


### PR DESCRIPTION
## Summary
- add an Ollama HTTP client and route smalltalk or unknown queries to the local model
- update intent routing to separate file search vs open, refine browser selection, and respect session model overrides
- extend app and search utilities plus add comprehensive tests for the new behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d93a141b2083209ec4ddc68a0d3a22