### PR TITLE
Add typed file creation and verification support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pyyaml==6.0.1
 rich==13.9.3
 prompt_toolkit==3.0.47
 rapidfuzz==3.5.2
+python-docx==0.8.11
 
 # Автоматизация браузера
 playwright==1.45.0

--- a/tests/test_create_edit.py
+++ b/tests/test_create_edit.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import os
+
+import pytest
+from docx import Document
+
+import config
+from intent_router import AgentSession, IntentRouter, SessionState
+
+
+@pytest.fixture()
+def router_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    allow_dir = tmp_path / "allow"
+    allow_dir.mkdir()
+
+    def fake_load_config(name: str) -> dict:
+        if name == "paths":
+            return {"whitelist": [str(allow_dir)], "default_downloads": str(allow_dir)}
+        if name == "apps":
+            return {"apps": {}}
+        if name == "web":
+            return {"browser": "chromium", "headless": True, "implicit_wait_ms": 1000}
+        raise KeyError(name)
+
+    config.refresh_cache()
+    monkeypatch.setenv("LOCALWINAGENT_INLINE_SANDBOX", "1")
+    monkeypatch.setattr(config, "load_config", fake_load_config)
+    monkeypatch.setattr("intent_router.load_config", fake_load_config)
+
+    router = IntentRouter()
+    session = AgentSession()
+    state = SessionState()
+
+    if not hasattr(os, "startfile"):
+        monkeypatch.setattr(os, "startfile", lambda *_args, **_kwargs: None, raising=False)
+
+    return router, session, state, allow_dir
+
+
+def _read_docx_text(path: Path) -> str:
+    document = Document(path)
+    return "\n".join(paragraph.text for paragraph in document.paragraphs)
+
+
+def test_create_word_document_with_content(router_env) -> None:
+    router, session, state, allow_dir = router_env
+    message = 'создай документ word отчет с текстом "Привет, мир"'
+    response = router.handle_message(message, session, state)
+
+    target = (allow_dir / "отчет.docx").resolve(strict=False)
+    assert target.exists()
+    assert _read_docx_text(target).strip() == "Привет, мир"
+
+    info = response["data"]["result"]
+    assert info["path"] == str(target)
+    assert info["verified"] is True
+    assert info["status"] == "created"
+    assert response["ok"] is True
+
+
+def test_create_text_file_with_content(router_env) -> None:
+    router, session, state, allow_dir = router_env
+    message = "создай текстовый файл заметка: сделать план"
+    response = router.handle_message(message, session, state)
+
+    target = (allow_dir / "заметка.txt").resolve(strict=False)
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == "сделать план"
+
+    info = response["data"]["result"]
+    assert info["path"] == str(target)
+    assert info["status"] == "created"
+    assert info["verified"] is True
+
+
+def test_overwrite_and_append(router_env) -> None:
+    router, session, state, allow_dir = router_env
+    router.handle_message('создай текстовый файл записка: первая строка', session, state)
+
+    overwrite = router.handle_message('перезапиши в записка.txt текст "Вторая"', session, state)
+    target = (allow_dir / "записка.txt").resolve(strict=False)
+    assert target.read_text(encoding="utf-8") == "Вторая"
+    assert overwrite["data"]["result"]["status"] == "overwritten"
+    assert overwrite["data"]["result"]["verified"] is True
+
+    append = router.handle_message('допиши в записка.txt текст " +доп"', session, state)
+    assert target.read_text(encoding="utf-8") == "Вторая +доп"
+    assert append["data"]["result"]["status"] == "appended"
+    assert append["data"]["result"]["verified"] is True
+
+
+def test_confirmation_required_outside(router_env, tmp_path: Path) -> None:
+    router, session, state, _ = router_env
+    outside = (tmp_path / "outside" / "data.txt").resolve(strict=False)
+    message = f'запиши в {outside} текст "секрет"'
+    response = router.handle_message(message, session, state)
+
+    assert response["requires_confirmation"] is True
+    info = response["data"]["result"]
+    assert info["requires_confirmation"] is True
+    assert info["verified"] is False
+    assert info["path"] == str(outside)
+    assert not outside.exists()

--- a/tools/docx_writer.py
+++ b/tools/docx_writer.py
@@ -1,0 +1,45 @@
+"""Помощники для работы с документами Word (.docx)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from docx import Document
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _add_paragraphs(document: Document, content: str, *, replace_first: bool) -> None:
+    lines = content.splitlines() if content else [""]
+    for index, line in enumerate(lines):
+        if replace_first and index == 0 and document.paragraphs:
+            document.paragraphs[0].text = line
+        else:
+            document.add_paragraph(line)
+
+
+def write_docx(path: str | Path, content: str) -> None:
+    """Создать или перезаписать документ .docx указанным содержимым."""
+
+    target = Path(path)
+    _ensure_parent(target)
+    document = Document()
+    _add_paragraphs(document, content, replace_first=True)
+    document.save(target)
+
+
+def append_docx(path: str | Path, content: str) -> None:
+    """Добавить текст в существующий документ .docx, создавая при необходимости."""
+
+    target = Path(path)
+    _ensure_parent(target)
+    if target.exists():
+        document = Document(target)
+        replace_first = False
+    else:
+        document = Document()
+        replace_first = True
+    _add_paragraphs(document, content, replace_first=replace_first)
+    document.save(target)


### PR DESCRIPTION
## Summary
- map natural-language file type hints to default extensions and capture inline content when creating files
- extend FileManager to support docx writes, add verification metadata, and provide a dedicated docx writer helper
- add focused tests for creating and editing files and declare the python-docx dependency

## Testing
- pytest tests/test_create_edit.py tests/test_file_intents.py tests/test_files.py

------
https://chatgpt.com/codex/tasks/task_e_68d94053e0a08320810ec8160567fbfa