### PR TITLE
Refine intent handling for generated text and app control

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,9 @@ rich==13.9.3
 prompt_toolkit==3.0.47
 rapidfuzz==3.5.2
 
+# Системные утилиты
+psutil==5.9.8
+
 # Автоматизация браузера
 playwright==1.45.0
 


### PR DESCRIPTION
## Summary
- detect generated text commands for TXT files, support app closing intents, and keep file search responses to listing results
- harden DOCX editing against PackageNotFoundError and add newline-aware insertion logic
- register the Photos app with psutil-based closing and add required dependencies

## Testing
- python -m py_compile intent_router.py
- python -m py_compile tools/files.py tools/apps.py

------
https://chatgpt.com/codex/tasks/task_e_68d94b23d8d08320b8877f674ca92a84